### PR TITLE
📝 docs: remove verbose license summary from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,6 @@ This project is based on and extends the original [cf-identity-dynamic](https://
 
 This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.
 
-### License Summary
-
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 ---
 


### PR DESCRIPTION
## Summary

Clean up the README.md by removing redundant GPL license text that duplicates information already available in the LICENSE file.

## Type of Change
- [x] Documentation update

## Changes Made
- **Removed verbose license summary**: Eliminated redundant GPL license text from README.md
- **Maintained clean reference**: Kept simple reference to LICENSE file
- **Improved readability**: Reduced documentation verbosity while preserving essential information

## Impact
This change streamlines the README by removing 5 lines of verbose legal text that was duplicating the full LICENSE file content. The license section now contains only a clean reference to the actual license file.

## Testing
- ✅ ESLint passes with no errors
- ✅ TypeScript compilation successful
- ✅ Documentation remains complete and accessible

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated appropriately
- [x] License information remains accessible via LICENSE file